### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/AldoGiovanniGiacomo.API/AldoGiovanniGiacomo.API.csproj
+++ b/AldoGiovanniGiacomo.API/AldoGiovanniGiacomo.API.csproj
@@ -41,10 +41,10 @@
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Api.Analyzers" Version="2.2.6" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="5.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.2" />
-    <PackageReference Include="NSwag.AspNetCore" Version="13.10.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="5.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.7" />
+    <PackageReference Include="NSwag.AspNetCore" Version="13.10.9" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Hi@giuseppebrb, I found an issue in the AldoGiovanniGiacomo.API.csproj:

Packages Microsoft.EntityFrameworkCore.Proxies v5.0.2, Microsoft.EntityFrameworkCore.Relational v5.0.2, Microsoft.EntityFrameworkCore.SqlServer v5.0.2 and NSwag.AspNetCore v13.10.1 transitively introduce 159 dependencies into AldoGiovanniGiacomo.API’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/AldoGiovanniGiacomo-API.html)), while Microsoft.EntityFrameworkCore.Proxies v5.0.5, Microsoft.EntityFrameworkCore.Relational v5.0.7, Microsoft.EntityFrameworkCore.SqlServer v5.0.7 and NSwag.AspNetCore v13.10.9 can only introduce 109 dependencies ([see dependency graph after upgrades](http://202.182.124.107:8000/AldoGiovanniGiacomo-API_after.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose